### PR TITLE
Use Repo.insert! to avoid tuple value

### DIFF
--- a/lib/secret_santa_api/secret_santa/secret_santa.ex
+++ b/lib/secret_santa_api/secret_santa/secret_santa.ex
@@ -14,7 +14,7 @@ defmodule SecretSantaApi.SecretSanta do
   def create_party(attrs \\ %{}) do
     %Party{}
     |> party_changeset(attrs)
-    |> Repo.insert()
+    |> Repo.insert!()
   end
 
   defp party_changeset(%Party{} = party, attrs) do


### PR DESCRIPTION
`insert!` returns `party` whereas `insert` returns `{:ok, party}`. Using `insert!` fixes the issue of Poison not knowing how to encode a tuple into JSON by... avoiding the tuple altogether. Note there are other ways of fixing this that may be more desirable such as pattern matching on the tuple and returning a JSON error otherwise. I will explore those later.